### PR TITLE
Notify a resource when it has been leaked

### DIFF
--- a/LargeCollections.Tests/Properties/AssemblyInfo.cs
+++ b/LargeCollections.Tests/Properties/AssemblyInfo.cs
@@ -23,7 +23,7 @@ using NUnit.Framework;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("3097e82b-f4ca-4d5d-99c3-8ac54fb73f0f")]
 
-[assembly: AssemblyVersion("9.2.0")]
-[assembly: AssemblyFileVersion("9.2.0")]
+[assembly: AssemblyVersion("9.3.0")]
+[assembly: AssemblyFileVersion("9.3.0")]
 
 [assembly: Parallelizable]

--- a/LargeCollections/Properties/AssemblyInfo.cs
+++ b/LargeCollections/Properties/AssemblyInfo.cs
@@ -22,5 +22,5 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("de860a46-69da-4018-8881-d02e79f702a3")]
 
-[assembly: AssemblyVersion("9.0.1")]
-[assembly: AssemblyFileVersion("9.0.1")]
+[assembly: AssemblyVersion("9.1.0")]
+[assembly: AssemblyFileVersion("9.1.0")]

--- a/LargeCollections/Resources/ReferenceCountedResource.cs
+++ b/LargeCollections/Resources/ReferenceCountedResource.cs
@@ -74,6 +74,10 @@ namespace LargeCollections.Resources
         {
         }
 
+        protected virtual void WasLeaked()
+        {
+        }
+
         private readonly IList<Reference> references = new SynchronizedCollection<Reference>();
         
 
@@ -90,6 +94,7 @@ namespace LargeCollections.Resources
                 if (RefCount == 0) return; // construction failed.
 
                 Diagnostics.Leaked(this);
+                WasLeaked();
 
                 log.DebugFormat("Resource leaked : {0}", this);
                 // really unsafe:


### PR DESCRIPTION
This feature should never be used for anything other than extra logging,
or maybe triggering debug assertions. Do not try to handle it in a
clever way.

LargeCollections: 9.0.1 -> 9.1.0
LargeCollections.Tests: 9.2.0 -> 9.3.0